### PR TITLE
refactor: Use enum for LOG_LEVEL in start/env.ts

### DIFF
--- a/start/env.ts
+++ b/start/env.ts
@@ -16,5 +16,5 @@ export default await Env.create(new URL('../', import.meta.url), {
   PORT: Env.schema.number(),
   APP_KEY: Env.schema.string(),
   HOST: Env.schema.string({ format: 'host' }),
-  LOG_LEVEL: Env.schema.string(),
+  LOG_LEVEL: Env.schema.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']),
 })


### PR DESCRIPTION
### 🔗 Linked issue

Asked on [discord](https://discord.com/channels/423256550564691970/423256550564691972/1243597619180343358) about making this change.

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change is because by default Pino only has a fixed number of log levels, and previously the string validator would allow through an invalid log level, which could cause issues when interacting with Pino.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

I'm not sure which documentation would need updating
