### PR TITLE
fix: usage 0.0.0.0 instead of localhost by default in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TZ=UTC
 PORT=3333
-HOST=localhost
+HOST=0.0.0.0
 LOG_LEVEL=info
 APP_KEY=zKXHe-Ahdb7aPK1ylAJlRgTefktEaACi
 NODE_ENV=development


### PR DESCRIPTION
By default, when creating an Adonis app, we can't access the running application using `127.0.0.1` which is unexpected.
While someone can easily find out, it is because the `.env` is misconfigured, and should set `HOST=0.0.0.0` it can still be quite cumbersome to understand and find out why it is not working.

This PR, change the default provided in `.env.example`.
If you accept this PR, I will be able to open similar PRs for the other starter kits: https://github.com/adonisjs/web-starter-kit and https://github.com/adonisjs/slim-starter-kit