### PR TITLE
feat: migrate force_json_middleware to a named middleware

### DIFF
--- a/start/kernel.ts
+++ b/start/kernel.ts
@@ -24,7 +24,6 @@ server.errorHandler(() => import('#exceptions/handler'))
  */
 server.use([
   () => import('#middleware/container_bindings_middleware'),
-  () => import('#middleware/force_json_response_middleware'),
   () => import('@adonisjs/cors/cors_middleware'),
 ])
 
@@ -38,4 +37,6 @@ router.use([() => import('@adonisjs/core/bodyparser_middleware')])
  * Named middleware collection must be explicitly assigned to
  * the routes or the routes group.
  */
-export const middleware = router.named({})
+export const middleware = router.named({
+  forceJsonResponse: () => import('#middleware/force_json_response_middleware'),
+})

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -8,9 +8,15 @@
 */
 
 import router from '@adonisjs/core/services/router'
+import { middleware } from './kernel.js'
 
-router.get('/', async () => {
-  return {
-    hello: 'world',
-  }
-})
+router
+  .group(() => {
+    router.get('/', async () => {
+      return {
+        hello: 'world',
+      }
+    })
+  })
+  .use(middleware.forceJsonResponse())
+  .as('api')


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->
### 🔗 Linked issue

https://github.com/FriendsOfAdonis/FriendsOfAdonis/issues/48

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull-request removes the `ForceJsonResponseMiddleware` from the server middlewares and add it to the named middleware. The `start/routes.ts` is updated accordingly by providing an initial `api` group that uses this middleware.

This allows library authors to perform content-negotiation without requiring users to update their existing codebase. And this is a main issue for `@foadonis/openapi` where the content returned depends on the `Accept` header allowing them to use the same route for documentation UI and in tools like `openapi-typescript`.

---

On a side not I think this middleware should not exist at all. Libraries should instead rely on content negotiation as it is already something managed by browsers.

For example, here is the default Accept header on Chrome
- document request: `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7`
- fetch request: `*/*`

With the following example, `Accept` is `html` on document request and `json` on fetch request.
```ts
router.get('/', ({ request }) => {
  const accept = request.accepts(['json', 'html'])
})
```

> Also users should always define their accept header when making api request but this is a different story.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (n/a)
